### PR TITLE
Corrects pattern in isTimePresent to use delimiters.

### DIFF
--- a/src/Object/DateFormat.php
+++ b/src/Object/DateFormat.php
@@ -194,7 +194,7 @@ class DateFormat
   {
     if (is_null($this->time_present))
     {
-      $this->time_present = preg_match(static::PATTERN_TIME, $this->string);
+      $this->time_present = preg_match('#'.static::PATTERN_TIME.'#', $this->string);
     }
 
     return $this->time_present;


### PR DESCRIPTION
The pattern in the constant does not have delimiters, so any usage must add them.