### PR TITLE
Reduce Years Where Appropriate

### DIFF
--- a/src/Helper/DatePeriodFormatter.php
+++ b/src/Helper/DatePeriodFormatter.php
@@ -50,7 +50,7 @@ class DatePeriodFormatter
   {
     $DateFormat = new DateFormat($format);
 
-    if ($this->isSameDateTime())
+    if ($this->isSameDateTime() || ($this->isSameDay() && empty($DateFormat->getTimePart())))
     {
       return $this->period->getStartDate()->format($format);
     }

--- a/src/Helper/DatePeriodFormatter.php
+++ b/src/Helper/DatePeriodFormatter.php
@@ -65,6 +65,12 @@ class DatePeriodFormatter
           $EndFormat = $DateFormat->replace('/([FmMn]+)(.*)/', '$2');
         }
       }
+
+      if ($this->isSameYear() && $DateFormat->isYearPresent() && !$DateFormat->isDateSeparated())
+      {
+        $EndFormat  = $EndFormat ?? $DateFormat;
+        $DateFormat = $DateFormat->replace('/\s([XxYy]+)/', '');
+      }
     }
     elseif ($DateFormat->isDatePresent())
     {

--- a/src/Helper/DatePeriodFormatter.php
+++ b/src/Helper/DatePeriodFormatter.php
@@ -70,6 +70,11 @@ class DatePeriodFormatter
       {
         $EndFormat  = $EndFormat ?? $DateFormat;
         $DateFormat = $DateFormat->replace('/\s([XxYy]+)/', '');
+
+        if ($this->isSameMonth() && (!$DateFormat->isTimePresent() || $this->isSameTime()))
+        {
+          $EndFormat = $EndFormat->replace('/([FmMn]+)(.*)/', '$2');
+        }
       }
     }
     elseif ($DateFormat->isDatePresent())


### PR DESCRIPTION
Three items in this PR:

When dates are on the same day, treats a format without time the same as if the dates have identical times.
- When dates have the same year, the format has the year, and there are no separators -- remove the year from leading format.  (IE: June 15 - June 18 2025)
- When dates have the same year & month, the format has year & month, and there are no separators -- remove month from end format (IE: June 15-18 2025)